### PR TITLE
Use header()’s http_response_code parameter

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -142,7 +142,7 @@ class Extension_APIPage extends Extension
         }
 
         if (isset($_SERVER['HTTP_IF_NONE_MATCH']) and $etag === $_SERVER['HTTP_IF_NONE_MATCH']) {
-            header('HTTP/1.1 304 Not Modified');
+            header('Status: 304 Not Modified', true, 304)
             exit(0);
         }
     }


### PR DESCRIPTION
This allows PHP to send the status response header in a way that's suitable for webservers whether they require the [HTTP](http://tools.ietf.org/html/rfc2616#section-6.1) or [CGI](http://tools.ietf.org/html/rfc3875#section-6.3.3) method.

[Related change in Symphony core](https://github.com/symphonycms/symphony-2/commit/82341ea766cdf05b89f08d1ed1985c7124984670).

[Related discussion](https://github.com/symphonycms/symphony-2/issues/972).
